### PR TITLE
Fixing how the switch works for routers

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -4,12 +4,14 @@ import React from 'react';
 import {
   Redirect,
   BrowserRouter as Router,
+  Route,
+  Switch,
 } from 'react-router-dom';
 
 import settings from './app/settings';
 import IcbcDataRouter from './icbc_data/router';
 import UploadRouter from './uploads/router';
-import DashboardRouter from './dashboard/router';
+import DashboardContainer from './dashboard/DashboardContainer';
 
 const { API_BASE } = settings;
 
@@ -37,9 +39,13 @@ const App = () => {
             <Redirect to={redirect} />
           )}
 
-          <UploadRouter />
-          <IcbcDataRouter />
-          <DashboardRouter />
+          <Switch>
+            {IcbcDataRouter()}
+            {UploadRouter()}
+            <Route>
+              <DashboardContainer />
+            </Route>
+          </Switch>
         </Router>
       </div>
     </div>

--- a/react/src/dashboard/DashboardContainer.js
+++ b/react/src/dashboard/DashboardContainer.js
@@ -1,18 +1,11 @@
-import React from 'react';
 import { withRouter, useHistory } from 'react-router-dom';
 
 const DashboardContainer = () => {
-  const { location } = window;
-  const { pathname } = location;
   const history = useHistory();
-  return (
 
-    <div className="row">
-      <div className="col-12">
-        {pathname === '/' && history.push('/upload')}
-      </div>
-    </div>
-  );
+  history.push('/upload');
+
+  return null;
 };
 
 export default withRouter(DashboardContainer);

--- a/react/src/dashboard/router.js
+++ b/react/src/dashboard/router.js
@@ -6,7 +6,6 @@ import DashboardContainer from './DashboardContainer';
 const Router = () => (
   <>
     <Route
-      exact
       path="/"
       component={DashboardContainer}
     />

--- a/react/src/icbc_data/router.js
+++ b/react/src/icbc_data/router.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 import IcbcDataContainer from './IcbcDataContainer';
 
-const Router = () => (
-  <Switch>
-    <Route
-      exact
-      path="/icbc"
-    >
-      <IcbcDataContainer />
-    </Route>
-  </Switch>
-);
+const Router = () => ([
+  <Route
+    exact
+    key="route-icbc"
+    path="/icbc"
+  >
+    <IcbcDataContainer />
+  </Route>,
+]);
 
 export default Router;

--- a/react/src/uploads/router.js
+++ b/react/src/uploads/router.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 import UploadContainer from './UploadContainer';
 
-const Router = () => (
-  <Switch>
-    <Route
-      exact
-      path="/upload"
-    >
-      <UploadContainer />
-    </Route>
-  </Switch>
-);
+const Router = () => ([
+  <Route
+    exact
+    key="route-upload"
+    path="/upload"
+  >
+    <UploadContainer />
+  </Route>,
+]);
 
 export default Router;


### PR DESCRIPTION
Previous implementation didn't work as well as intended. It was throwing errors about unmounted components as it was trying to load the ICBC container after it loaded the Upload container

Changelog:
- Now calling the routers as functions
- Moved Switch to App.js so it only uses the first route it matches with the URL
- DashboardContainer is currently the default fallback (will have to replace this with a 404 or something else)