### PR TITLE
Combined the superset containers into one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,46 +42,13 @@ services:
   superset:
     env_file: ./superset.env
     image: apache/superset:latest-dev
-    command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+    command: ["/app/docker/run.sh"]
     user: "root"
     ports:
       - 8088:8088
     depends_on:
       - db
       - redis
-    volumes:
-      - ./superset:/app/docker
-      - superset_home:/app/superset_home
-  superset-init:
-    image: apache/superset:latest-dev
-    command: ["/app/docker/docker-init.sh"]
-    env_file: ./superset.env
-    depends_on:
-      - db
-      - redis
-    user: "root"
-    volumes:
-      - ./superset:/app/docker
-      - superset_home:/app/superset_home
-  superset-worker:
-    image: apache/superset:latest-dev
-    command: ["/app/docker/docker-bootstrap.sh", "worker"]
-    env_file: ./superset.env
-    depends_on:
-      - db
-      - redis
-    user: "root"
-    volumes:
-      - ./superset:/app/docker
-      - superset_home:/app/superset_home
-  superset-worker-beat:
-    image: apache/superset:latest-dev
-    command: ["/app/docker/docker-bootstrap.sh", "beat"]
-    env_file: ./superset.env
-    depends_on:
-      - db
-      - redis
-    user: "root"
     volumes:
       - ./superset:/app/docker
       - superset_home:/app/superset_home

--- a/superset.env
+++ b/superset.env
@@ -7,9 +7,6 @@ DATABASE_USER=postgres
 
 DATABASE_PORT=5432
 DATABASE_DIALECT=postgresql
-POSTGRES_DB=superset
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
 
 # Add the mapped in /app/pythonpath_docker which allows devs to override stuff
 PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev

--- a/superset/run.sh
+++ b/superset/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+/app/docker/docker-init.sh &
+
+/app/docker/docker-bootstrap.sh worker &
+/app/docker/docker-bootstrap.sh beat &
+
+/app/docker/docker-bootstrap.sh app-gunicorn


### PR DESCRIPTION
Superset's example by default uses 4 containers just to start it. I found this to be unnecessary and just adds clutter.

Changelog:
- Removed supset-init, superset-worker, superset-worker-beat
- Added run.sh to run worker, beat and init in the background