### PR TITLE
fix: 169 - get uploader working on test

### DIFF
--- a/django/api/services/minio.py
+++ b/django/api/services/minio.py
@@ -11,10 +11,17 @@ MINIO = Minio(
 )
 
 
+def get_refined_object_name(object_name):
+    prefix = settings.MINIO_PREFIX
+    if prefix:
+        return prefix + '/' + object_name
+    return object_name
+
+
 def minio_get_object(object_name):
     return MINIO.presigned_get_object(
         bucket_name=settings.MINIO_BUCKET_NAME,
-        object_name=object_name,
+        object_name=get_refined_object_name(object_name),
         expires=timedelta(seconds=3600)
     )
 
@@ -22,7 +29,7 @@ def minio_get_object(object_name):
 def minio_put_object(object_name):
     return MINIO.presigned_put_object(
         bucket_name=settings.MINIO_BUCKET_NAME,
-        object_name=object_name,
+        object_name=get_refined_object_name(object_name),
         expires=timedelta(seconds=7200)
     )
 
@@ -30,5 +37,5 @@ def minio_put_object(object_name):
 def minio_remove_object(object_name):
     return MINIO.remove_object(
         bucket_name=settings.MINIO_BUCKET_NAME,
-        object_name=object_name
+        object_name=get_refined_object_name(object_name),
     )

--- a/django/api/settings.py
+++ b/django/api/settings.py
@@ -159,6 +159,7 @@ MINIO_ENDPOINT = os.getenv('MINIO_ENDPOINT', None)
 MINIO_USE_SSL = bool(
     os.getenv('MINIO_USE_SSL', 'False').lower() in ['true', 1]
 )
+MINIO_PREFIX = os.getenv('MINIO_PREFIX')
 
 
 DECODER_ACCESS_KEY = os.getenv('DECODER_ACCESS_KEY')


### PR DESCRIPTION
As part of the fixes to the uploader, we switched to using external object storage, and with that we are putting uploaded cthub files into a subfolder within the bucket.