### PR TITLE
feat/fix  - 337 and 324 - vinpower job + google dns resolver for email validation

### DIFF
--- a/django/api/constants/constants.py
+++ b/django/api/constants/constants.py
@@ -24,6 +24,7 @@ from api.services.spreadsheet_uploader_prep import (
     location_checker,
     email_validator
 )
+from api.services.resolvers import get_google_resolver
 
 
 class ARCProjectTrackingColumns(Enum):
@@ -655,7 +656,7 @@ DATASET_CONFIG = {
             {"error_type": "Phone Error", "function": validate_phone_numbers, "columns": ["Phone Number"], "kwargs": {"indices_offset": 2}},
             {"error_type": "Potential Typo", "function": typo_checker, "columns": ["Applicant Name"], "kwargs": {"cutoff": 0.8, "indices_offset": 2}},
             {"error_type": "Location Not Found", "function": location_checker, "columns": ["City"], "kwargs": {"indices_offset":2}},
-            {"error_type": "Invalid Email", "function": email_validator, "columns": ["Email"], "kwargs": {"indices_offset":2}}
+            {"error_type": "Invalid Email", "function": email_validator, "columns": ["Email"], "kwargs": {"indices_offset":2, "get_resolver": get_google_resolver}}
         ]
     },
 }

--- a/django/api/services/resolvers.py
+++ b/django/api/services/resolvers.py
@@ -1,0 +1,7 @@
+from dns.resolver import Resolver
+
+
+def get_google_resolver():
+    resolver = Resolver()
+    resolver.nameservers = ["8.8.8.8"]
+    return resolver

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -24,4 +24,5 @@ openpyxl==3.0.9
 minio==7.1.1
 xlsxwriter==3.2.0
 xmltodict==0.13.0
+dnspython==2.6.1
 email-validator==2.2.0

--- a/django/workers/apps.py
+++ b/django/workers/apps.py
@@ -9,10 +9,12 @@ class Config(AppConfig):
         from workers.scheduled_jobs import (
             schedule_create_minio_bucket,
             schedule_read_uploaded_vins_file,
-            schedule_batch_decode_vins,
+            schedule_batch_decode_vins_vpic,
+            schedule_batch_decode_vins_vinpower,
         )
 
         if "qcluster" in sys.argv:
             schedule_create_minio_bucket()
             schedule_read_uploaded_vins_file()
-            schedule_batch_decode_vins()
+            schedule_batch_decode_vins_vpic()
+            schedule_batch_decode_vins_vinpower()

--- a/django/workers/scheduled_jobs.py
+++ b/django/workers/scheduled_jobs.py
@@ -27,13 +27,28 @@ def schedule_read_uploaded_vins_file():
         pass
 
 
-def schedule_batch_decode_vins():
+def schedule_batch_decode_vins_vpic():
     try:
         schedule(
             "workers.tasks.batch_decode_vins",
             "vpic",
             50,
-            name="batch_decode_vins",
+            name="vpic_batch_decode_vins",
+            schedule_type="C",
+            cron="*/2 * * * *",
+            q_options={"timeout": 105, "ack_failure": True},
+        )
+    except IntegrityError:
+        pass
+
+
+def schedule_batch_decode_vins_vinpower():
+    try:
+        schedule(
+            "workers.tasks.batch_decode_vins",
+            "vinpower",
+            2000,
+            name="vinpower_batch_decode_vins",
             schedule_type="C",
             cron="*/2 * * * *",
             q_options={"timeout": 105, "ack_failure": True},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,14 @@ services:
       - /web/node_modules
     ports:
       - 3000:3000
+  spring:
+    build: ./spring
+    ports:
+      - "8080:8080"
+    environment:
+      - SERVER_PORT=8080
+    volumes:
+      - ./spring:/app
 
 volumes:
   superset_home:

--- a/spring/.gitignore
+++ b/spring/.gitignore
@@ -16,3 +16,4 @@ build/*
 .vscode
 _site/
 *.css
+libs/*

--- a/spring/Dockerfile-Openshift
+++ b/spring/Dockerfile-Openshift
@@ -26,4 +26,4 @@ RUN ./mvnw dependency:resolve
 
 COPY src ./src
 
-CMD ["./mvnw", "-Denvironment=localDev", "spring-boot:run"]
+CMD ["./mvnw", "-Denvironment=production", "spring-boot:run"]


### PR DESCRIPTION
Remarks:

(1) Looks like the vinpower service is running on openshift dev now, so we can instantiate the job that uses that service to decode vins
(2) Noticed that the email_validator is not working as expected on dev, but it is locally; I think this is because my local nameserver is different from the openshift container's nameserver; switch to use google's dns server in both cases to see if this resolves the issue.
(3) Developers will need the vinpower jar in order for the spring service to work locally; the jar is on Teams: Team Zelda -> _CTHUB_ -> Vin Decoding -> vinpower -> Java -> vp4jo_bttm_msrp_gvw_50011.jar. Locally, please put this jar in /spring/libs