### PR TITLE
fix: 366 - (vin decoding jobs)/resolver fixes/changes

### DIFF
--- a/django/api/services/decoded_vin_record.py
+++ b/django/api/services/decoded_vin_record.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 def save_decoded_data(
     uploaded_vin_records,
     vins_to_insert,
-    decoded_records_to_update_map,
+    vins_to_decoded_record_ids_map,
     service_name,
     decoded_data,
 ):
@@ -34,10 +34,12 @@ def save_decoded_data(
                     decoded_records_to_insert.append(
                         decoded_vin_model(vin=vin, data=decoded_datum)
                     )
-                elif vin in decoded_records_to_update_map:
-                    decoded_record_to_update = decoded_records_to_update_map.get(vin)
-                    decoded_record_to_update.update_timestamp = timezone.now()
-                    decoded_record_to_update.data = decoded_datum
+                elif vin in vins_to_decoded_record_ids_map:
+                    decoded_record_to_update = decoded_vin_model(
+                        id=vins_to_decoded_record_ids_map[vin],
+                        update_timestamp=timezone.now(),
+                        data=decoded_datum,
+                    )
                     decoded_records_to_update.append(decoded_record_to_update)
             elif vin in failed_vins:
                 set_decode_successful(service_name, uploaded_record, False)

--- a/django/api/services/resolvers.py
+++ b/django/api/services/resolvers.py
@@ -1,7 +1,8 @@
 from dns.resolver import Resolver
+from email_validator import caching_resolver
 
 
 def get_google_resolver():
     resolver = Resolver()
     resolver.nameservers = ["8.8.8.8"]
-    return resolver
+    return caching_resolver(dns_resolver=resolver)

--- a/django/api/utilities/generic.py
+++ b/django/api/utilities/generic.py
@@ -4,3 +4,12 @@ def get_map(key_name, objects):
         key = getattr(object, key_name)
         result[key] = object
     return result
+
+
+def get_unified_map(key_name, value_name, maps):
+    result = {}
+    for map in maps:
+        key = map.get(key_name)
+        value = map.get(value_name)
+        result[key] = value
+    return result

--- a/django/workers/external_apis/vinpower.py
+++ b/django/workers/external_apis/vinpower.py
@@ -14,7 +14,7 @@ def batch_decode(uploaded_vin_records):
         vins.append(record.vin)
     headers = {"content-type": "application/json"}
     response = requests.get(url, data=json.dumps(vins), headers=headers)
-    response.raise_for_status
+    response.raise_for_status()
 
     data = response.json()
     for vin in vins:

--- a/django/workers/external_apis/vpic.py
+++ b/django/workers/external_apis/vpic.py
@@ -17,7 +17,7 @@ def batch_decode(uploaded_vin_records):
 
     body = {"format": "json", "data": request_data}
     response = requests.post(url, data=body)
-    response.raise_for_status
+    response.raise_for_status()
     data = response.json()["Results"]
     decoded_vins_map = {}
     for record in data:


### PR DESCRIPTION
Do some fixes related to the vin decoding job(s):
(1) calls to raise_for_status() in external apis
(2) load only necessary fields of decoded vin records when updating vin records

Also a change to the email_validator resolver:
(1) Use caching_resolver which should hopefully improve performance for large spreadsheets