### PR TITLE
Task: Format Warnings #393

### DIFF
--- a/django/api/services/spreadsheet_uploader.py
+++ b/django/api/services/spreadsheet_uploader.py
@@ -154,13 +154,20 @@ def transform_data(
                     errors_and_warnings[column] = {}
                 for issue, details in issues.items():
                     if issue not in errors_and_warnings[column]:
-                        errors_and_warnings[column][issue] = {
-                            "Expected Type": details.get("Expected Type", "Unknown"),
-                            "Rows": details.get("Rows", []),
-                            "Severity": details.get("Severity", "Error")
-                        }
+                        if(details.get("Severity", "Error") == 'Warning'):
+                            errors_and_warnings[column][issue] = {
+                                "Expected Type": details.get("Expected Type", "Unknown"),
+                                "Groups": details.get("Groups", []),
+                                "Severity": details.get("Severity", "Error")
+                            }
+                        else:
+                            errors_and_warnings[column][issue] = {
+                                "Expected Type": details.get("Expected Type", "Unknown"),
+                                "Rows": details.get("Rows", []),
+                                "Severity": details.get("Severity", "Error")
+                            }
                     else:
-                        errors_and_warnings[column][issue]["Rows"].extend(details.get("Rows", []))
+                        errors_and_warnings[column][issue]["Groups"].extend(details.get("Groups", []))
 
     column_mapping = {col.name: col.value for col in column_mapping_enum}
     inverse_column_mapping = {v: k for k, v in column_mapping.items()}

--- a/frontend/src/uploads/UploadContainer.js
+++ b/frontend/src/uploads/UploadContainer.js
@@ -64,44 +64,51 @@ const UploadContainer = () => {
       errors: 0,
       warnings: 0,
     };
-  
+
     issueArray.forEach((issue) => {
-  
       Object.keys(issue).forEach((column) => {
         const errorDetails = issue[column];
   
         Object.keys(errorDetails).forEach((errorType) => {
           const severity = errorDetails[errorType].Severity;
           const expectedType = errorDetails[errorType]["Expected Type"];
-          const rows = errorDetails[errorType].Rows;
-          const rowCount = rows.length;
+          const groups = errorDetails[errorType].Groups || [];
   
           if (severity === "Error") {
+            const rows = errorDetails[errorType].Rows;
+            const rowCount = rows.length;
             totalIssueCount.errors += rowCount;
+  
             if (!groupedErrors[column]) {
               groupedErrors[column] = {};
             }
             if (!groupedErrors[column][errorType]) {
               groupedErrors[column][errorType] = {
                 ExpectedType: expectedType,
-                Rows: rows,
+                Rows: [...rows],
               };
             } else {
               groupedErrors[column][errorType].Rows.push(...rows);
             }
           } else if (severity === "Warning") {
-            totalIssueCount.warnings += rowCount;
+            let warningRowCount = 0;
+  
             if (!groupedWarnings[column]) {
               groupedWarnings[column] = {};
             }
             if (!groupedWarnings[column][errorType]) {
               groupedWarnings[column][errorType] = {
                 ExpectedType: expectedType,
-                Rows: rows,
+                Groups: [],
               };
-            } else {
-              groupedWarnings[column][errorType].Rows.push(...rows);
             }
+  
+            groups.forEach((group) => {
+              groupedWarnings[column][errorType].Groups.push(group);
+              warningRowCount += group.Rows.length;
+            });
+  
+            totalIssueCount.warnings += warningRowCount;
           }
         });
       });
@@ -109,8 +116,6 @@ const UploadContainer = () => {
   
     return { groupedErrors, groupedWarnings, totalIssueCount };
   };
-  
-  
 
   const showError = (error) => {
     const { response: errorResponse } = error;

--- a/frontend/src/uploads/components/UploadIssuesDetail.js
+++ b/frontend/src/uploads/components/UploadIssuesDetail.js
@@ -1,19 +1,56 @@
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { Box, Button } from "@mui/material";
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const UploadIssuesDetail = ({ type, issues, totalIssueCount, msg }) => {
-  const [showAllRowsMap, setShowAllRowsMap] = useState({}); // State to toggle showing all rows for each issue
+  const [showAllRowsMap, setShowAllRowsMap] = useState({});
   const classname = type === "error" ? "error" : "warning";
-  const toggleShowAllRows = (column, errorType) => {
-    const key = `${column}_${errorType}`;
+  const toggleShowAllRows = (column, errorType, groupIndex) => {
+    const key = `${column}_${errorType}_${groupIndex}`;
     setShowAllRowsMap((prevState) => ({
       ...prevState,
       [key]: !prevState[key],
     }));
   };
+
+  const renderWarning = (group) => (
+    <>
+      <ul>
+        <li>
+          Rows:{" "}
+          <b>{group.Rows.join(", ")}</b>
+          {Object.keys(group).map((key) => {
+            if (key !== "Rows") {
+              return (
+                <span key={key}>
+                  {"       "} {/* spacer */}
+                  {Array.isArray(group[key])
+                    ? group[key].join(", ")
+                    : group[key]}
+                </span>
+              );
+            }
+            return null;
+          })}
+        </li>
+      </ul>
+    </>
+  );
+  
+  const renderError = (errorDetails) => (
+    <>
+      <ul>
+        <li>
+          <div>
+            Rows:{" "}
+            <b>{errorDetails.Rows.join(", ")}</b>
+          </div>
+        </li>
+      </ul>
+    </>
+  );
 
   return (
     <Box
@@ -29,49 +66,62 @@ const UploadIssuesDetail = ({ type, issues, totalIssueCount, msg }) => {
       />
       <span className={classname}>
         <strong>
-          {totalIssueCount} {type == 'error' ? 'Errors' : 'Warnings'}&nbsp;
+          {totalIssueCount} {type === "error" ? "Errors" : "Warnings"}&nbsp;
         </strong>
       </span>
       ({msg})
       {Object.keys(issues).map((column) => (
         <Box key={column} sx={{ marginTop: 2 }}>
           <strong>Column: {column}</strong>
-          {Object.keys(issues[column]).map((errorType, index) => (
-            <div key={index} style={{ marginTop: "0.5rem" }}>
-              <div>
-                {(Object.keys(issues[column]).length > 1 ? `(${index + 1}) ` : '')}
-                {type.charAt(0).toUpperCase() + type.slice(1)} Name: {errorType}
+          {Object.keys(issues[column]).map((errorType, index) => {
+            const errorDetails = issues[column][errorType];
+
+            return (
+              <div key={index} style={{ marginTop: "0.5rem" }}>
+                <div>
+                <ul>
+                  <li>
+                    <div>
+                      {(Object.keys(issues[column]).length > 1
+                        ? `(${index + 1}) `
+                        : "")}
+                      {type.charAt(0).toUpperCase() + type.slice(1)} Name:{" "}
+                      <strong>{errorType}</strong>
+                    </div>
+                  </li>
+                  </ul>
+                  <ul>
+                    <li>
+                      Expected Value:{" "}
+                      <b>{errorDetails.ExpectedType || errorDetails.ExpectedFormat}</b>
+                     </li>
+                  </ul>
                 </div>
-              <div>
-                Expected value:{" "}
-                {issues[column][errorType].ExpectedType ||
-                  issues[column][errorType].ExpectedFormat}
+                {errorDetails.Groups ? (
+                  errorDetails.Groups.map((group, groupIndex) => (
+                    <div key={groupIndex} style={{ marginTop: "0.5rem" }}>
+                      {renderWarning(group)}
+                      {group.Rows.length > 15 && (
+                        <Button
+                          variant="text"
+                          onClick={() =>
+                            toggleShowAllRows(column, errorType, groupIndex)
+                          }
+                        >
+                          {showAllRowsMap[`${column}_${errorType}_${groupIndex}`]
+                            ? "Show less"
+                            : "Show more"}{" "}
+                          <ExpandMoreIcon />
+                        </Button>
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  renderError(errorDetails)
+                )}
               </div>
-              <div>
-                Rows with {type}:{" "}
-                <b>
-                  {issues[column][errorType].Rows.slice(
-                    0,
-                    showAllRowsMap[`${column}_${errorType}`] ? undefined : 15,
-                  ).join(", ")}
-                  {issues[column][errorType].Rows.length > 15 &&
-                    !showAllRowsMap[`${column}_${errorType}`] &&
-                    "..."}
-                </b>
-              </div>
-              {issues[column][errorType].Rows.length > 15 && (
-                <Button
-                  variant="text"
-                  onClick={() => toggleShowAllRows(column, errorType)}
-                >
-                  {showAllRowsMap[`${column}_${errorType}`]
-                    ? "Show less"
-                    : "Show more"}{" "}
-                  <ExpandMoreIcon />
-                </Button>
-              )}
-            </div>
-          ))}
+            );
+          })}
         </Box>
       ))}
     </Box>


### PR DESCRIPTION
- Refactored backend warning functions to return object groups instead of arrays
- Updated counting logic to accomodate error arrays and warning groups
- Refactored frontend components to render warnings and errors differently; displaying extra information for warnings