### PR TITLE
CTHUB 456 - allow blank postal codes for GER dataset

### DIFF
--- a/django/api/constants/constants.py
+++ b/django/api/constants/constants.py
@@ -921,7 +921,7 @@ DATASET_CONFIG = {
             {"function": location_checker, "columns": ["City"], "kwargs": {"columns_to_features_map": {"City": LOCALITY_FEATURES_MAP}, "indices_offset":2}},
             {"function": email_validator, "columns": ["Email"], "kwargs": {"indices_offset":2, "get_resolver": get_google_resolver}},
             {"function": validate_field_values, "columns": [], "kwargs": {"indices_offset":2, "fields_and_values": GER_VALID_FIELD_VALUES}},
-            {"function": format_postal_codes, "columns": ["Postal code"], "kwargs": {"indices_offset":2, "validate": True}}
+            {"function": format_postal_codes, "columns": ["Postal code"], "kwargs": {"indices_offset":2, "validate": True, "allow_empty": True}}
         ]
     },
     "CVP Data": {

--- a/django/api/services/spreadsheet_uploader_prep.py
+++ b/django/api/services/spreadsheet_uploader_prep.py
@@ -429,6 +429,7 @@ def region_checker(df, *columns, **kwargs):
 
 def format_postal_codes(df, *columns, **kwargs):
     validate = kwargs.get('validate', False)
+    allow_empty = kwargs.get('allow_empty', False)
     indices_offset = kwargs.get("indices_offset", 0)
     
     result = {}
@@ -440,13 +441,12 @@ def format_postal_codes(df, *columns, **kwargs):
 
         for value, indices in map_of_values_to_indices.items():
             clean_value = value.replace(" ", "") if isinstance(value, str) else ""
-            
-            if len(clean_value) == 6:
+            if len(clean_value) == 6 or (allow_empty and len(clean_value) == 0):
                 formatted_value = clean_value[:3] + " " + clean_value[3:]
                 for index in indices:
                     df.at[index - indices_offset, column] = formatted_value
             elif validate:
-                if pd.isna(value) or value == "":
+                if (pd.isna(value) or value == "") and not allow_empty:
                     value = "Empty"
                 invalid_groups.append({
                     "invalid_postal_code": value,


### PR DESCRIPTION
adds argument for allowing blank postal codes to formatting function, passes allow_empty=True for GER datasets because that was what was specified by business area. May need to be modified to have the same behaviour for other datasets in the future.